### PR TITLE
Parse site info from config.

### DIFF
--- a/src/validated_types.rs
+++ b/src/validated_types.rs
@@ -5,9 +5,9 @@ pub struct Url(String);
 
 impl Url {
     /// Get a URL. `Err` if the item passed in is not a spec-conformant URL.
-    pub fn new(unvalidated_url: String) -> Result<Url, String> {
+    pub fn new(unvalidated_url: &str) -> Result<Url, String> {
         // TODO: validate the URLs!
-        Ok(Url(unvalidated_url))
+        Ok(Url(unvalidated_url.into()))
     }
 
     /// Get the value of a valid URL.

--- a/src/yaml_util.rs
+++ b/src/yaml_util.rs
@@ -23,7 +23,7 @@ impl fmt::Display for Required {
     }
 }
 
-pub fn required_key(key: &str, yaml: &yaml::Hash) -> String {
+pub fn required_key<Y: fmt::Debug>(key: &str, yaml: &Y) -> String {
     format!("Required key `{}` missing from {:?}", key, yaml)
 }
 

--- a/tests/scenarios/pelican/lightning.yaml
+++ b/tests/scenarios/pelican/lightning.yaml
@@ -10,18 +10,28 @@
 # TODO: extract relevant bits from this into docs once I stabilize it a bit.
 
 site_info:
+  # The `title` field is required, since you can't create well-formed HTML
+  # without a `<title>`.
   title: lx (lightning)
 
-  # Note that Lightning will check your URL; if it's badly formed, we'll warn you.
-  URL: https://lightning.rs  # I can wish and hope, right? And save my pennies.
+  # Note that Lightning will check your URL; if it's badly formed, we'll warn
+  # you... and refuse to generate the site!
+  url: https://lightning.rs  # I can wish and hope, right? And save my pennies.
 
+  # A description for the site. This is optional, but strongly recommended. You
+  # may leave the field out, or explicitly set it to null (`~`), if you do not
+  # want to use it.
   description: >
     A ridiculously fast site generator and engine.
 
   # You may supply any other metadata you like, though only as key-value pairs.
-  # Those pairs will be supplied to your templates as maps.
-  metadata: ~
-
+  # Those pairs will be supplied to your templates as hashmaps. The default
+  # value is null/`~` since no other metadata are assumed.
+#  metadata: ~
+  metadata:
+    foo: bar
+    quux: 42
+    baz: 13.3
 
 # Specify the source for the content. It can be any folder at all; relative
 # paths are resolved from the location of this configuration file.


### PR DESCRIPTION
Completes the "get it working" part of #20. A follow-up commit/PR will switch the rest of the module to using `match` with index-style access for the YAML keys.