### PR TITLE
Switch from pandoc to pulldown_cmark.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bitflags"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bitflags"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -106,11 +111,6 @@ version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "itertools"
-version = "0.4.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "itoa"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -140,7 +140,7 @@ version = "0.1.0"
 dependencies = [
  "clap 2.19.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "pandoc 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pulldown-cmark 0.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-xml 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -222,14 +222,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pandoc"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "itertools 0.4.19 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "pkg-config"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -252,6 +244,14 @@ version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -475,6 +475,7 @@ dependencies = [
 "checksum base64 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7c4a342b450b268e1be8036311e2c613d7f8a7ed31214dff1cc3b60852a3168d"
 "checksum bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e103c8b299b28a9c6990458b7013dc4a8356a9b854c51b9883241f5866fac36e"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
+"checksum bitflags 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1370e9fc2a6ae53aea8b7a5110edbd08836ed87c88736dfabccade1c2b44bff4"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "94f88df23a25417badc922ab0f5716cc1330e87f71ddd9203b3a3ccd9cedf75d"
 "checksum cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "f159dfd43363c4d08055a07703eb7a3406b0dac4d0584d96965a3262db3c9d16"
@@ -486,7 +487,6 @@ dependencies = [
 "checksum flate2 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)" = "e6234dd4468ae5d1e2dbb06fe2b058696fdc50a339c68a393aefbf00bc81e423"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
-"checksum itertools 0.4.19 (registry+https://github.com/rust-lang/crates.io-index)" = "c4a9b56eb56058f43dc66e58f40a214b2ccbc9f3df51861b63d51dec7b65bc3f"
 "checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
@@ -500,10 +500,10 @@ dependencies = [
 "checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
 "checksum onig 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1271a3f93197303deda8aedcd96ed2dbb908f61c0954ae70bf7a42f536dc35d7"
 "checksum onig_sys 65.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fbdee58fb75f5b7749ebc8f601f570961eed595dfe4c2bb9a542e2f7ae20b946"
-"checksum pandoc 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7e553500658a7c7bd39857a258c0c25aec1609c2f1f898ce67d089597a1f74bb"
 "checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
 "checksum plist 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c61ac2afed2856590ae79d6f358a24b85ece246d2aa134741a66d589519b7503"
 "checksum proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)" = "3d7b7eaaa90b4a90a932a9ea6666c95a389e424eff347f0f793979289429feee"
+"checksum pulldown-cmark 0.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "4c7c04a8bb38f80717527edea39c82378c2ef13ecdbc914cbd90653a2e24afdf"
 "checksum quick-xml 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "63c6540872d1a0a1b06c8542a4b6671cfa08c9caa13e346698cdbf2ac52b3530"
 "checksum quote 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "63b5829244f52738cfee93b3a165c1911388675be000c888d2fae620dee8fa5b"
 "checksum redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "c214e91d3ecf43e9a4e41e578973adeb14b474f2bee858742d127af75a0112b1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2018"
 
 [dependencies]
 glob = "0.2.11"
-pandoc = "0.5.0"
 quick-xml = "0.4.1"
+pulldown-cmark = { version = "0.0.11", default-features = false }
 serde = "1.0"
 serde_derive = "1.0"
 serde_yaml = "0.8"

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,6 +24,7 @@ pub struct Config {
     pub site: SiteInfo,
     pub directories: Directories,
     pub structure: Structure,
+    pub options: Options,
 }
 
 impl Config {
@@ -56,6 +57,22 @@ impl Config {
 pub struct Directories {
     pub content: PathBuf,
     pub output: PathBuf,
+}
+
+#[derive(Debug, PartialEq, Deserialize)]
+pub struct Options {
+    pub syntax: SyntaxOption,
+}
+
+#[derive(Debug, PartialEq, Deserialize)]
+#[serde(tag = "mode")]
+pub enum SyntaxOption {
+    #[serde(rename = "off")]
+    Off,
+    #[serde(rename = "tag only")]
+    TagOnly,
+    #[serde(rename = "full")]
+    Highlight(String),
 }
 
 #[derive(Debug, PartialEq, Deserialize)]
@@ -470,6 +487,9 @@ fn parses_default_config() {
                 copy: vec!["static".into(), "extra".into()],
                 exclude: Vec::new(),
             },
+        },
+        options: Options {
+            syntax: SyntaxOption::Off,
         },
     };
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -65,7 +65,6 @@ pub struct Options {
 }
 
 #[derive(Debug, PartialEq, Deserialize)]
-#[serde(tag = "mode")]
 pub enum SyntaxOption {
     #[serde(rename = "off")]
     Off,

--- a/src/syntax_highlighting.rs
+++ b/src/syntax_highlighting.rs
@@ -36,7 +36,7 @@ enum ParseState {
 /// Define XML parsing events of interest for highlighting.
 ///
 /// We don't care at all about any other items for this specific scenario; we
-/// use these in conjunction with the `ParseState` to drive the state  machine
+/// use these in conjunction with the `ParseState` to drive the state machine
 /// described there.
 #[derive(Debug)]
 enum ParseEvent {
@@ -76,14 +76,13 @@ impl Default for ParseState {
     }
 }
 
+const PRE: &[u8] = b"pre";
+const CODE: &[u8] = b"code";
+const CLASS: &[u8] = b"class";
+const WHITE_SPACE: &[u8] = b"";
+
 impl<'e> From<&'e Event> for ParseEvent {
     fn from(event: &'e Event) -> ParseEvent {
-        // TODO @1.15: remove `'static`.
-        const PRE: &'static [u8] = b"pre";
-        const CODE: &'static [u8] = b"code";
-        const CLASS: &'static [u8] = b"class";
-        const WHITE_SPACE: &'static [u8] = b"";
-
         match *event {
             Event::Start(ref element) => match element.name() {
                 PRE => {

--- a/tests/pure-config.yaml
+++ b/tests/pure-config.yaml
@@ -9,7 +9,7 @@ directories:
   output: output
 options:
   syntax:
-    off
+    off: ~
     #tag only
     # full: <theme>
 structure:

--- a/tests/pure-config.yaml
+++ b/tests/pure-config.yaml
@@ -7,6 +7,11 @@ site_info:
 directories:
   content: content
   output: output
+options:
+  syntax:
+    off
+    #tag only
+    # full: <theme>
 structure:
   directory: layout
   index: index.html

--- a/tests/scenarios/pelican/content/ycombinator.md
+++ b/tests/scenarios/pelican/content/ycombinator.md
@@ -238,4 +238,4 @@ And that's enough playing with combinatorials for now. (Except that I'm kind of 
 
 <i class=editorial>If you're curious how I worked this out... I expanded the JS representations of the final forms ([here's the code][JS]) and then stepped through the result in my JavaScript dev tools, watching how the function calls worked and what the values of each intermediate value were. It's fascinating, and well worth your time.</i>
 
-[JS]: //www.chriskrycho.com/extra/ycombinator.js
+[JS]: https://www.chriskrycho.com/extra/ycombinator.js

--- a/tests/scenarios/pelican/lightning.yaml
+++ b/tests/scenarios/pelican/lightning.yaml
@@ -33,6 +33,16 @@ site_info:
     quux: 42
     baz: 13.3
 
+options:
+  # Syntax may be one of `off`, `tag only`, or `full`. If it is `full`, it
+  # should be an "object" naming the highlighting theme to use. E.g.:
+  #
+  # ```yaml
+  # full: base16-ocean.dark
+  # ```
+  syntax:
+    off
+
 directories:
   # Specify the source for the content. It can be any folder at all; relative
   # paths are resolved from the location of this configuration file.

--- a/tests/scenarios/pelican/lightning.yaml
+++ b/tests/scenarios/pelican/lightning.yaml
@@ -198,7 +198,8 @@ structure:
     # is included, a full RSS feed of every time-categorized item on the site
     # will be generated. (NOTE: If there are no `temporal` taxonomies, feed
     # items will will be generated.)
-    engine: RSS  # `RSS` or `Atom`
+    engines: # One or more of `RSS`, `Atom`, or `JSON`
+      - RSS
 
     # Generate additional feeds be
     additional:
@@ -209,21 +210,18 @@ structure:
       # feeds will be <name of taxonomy item> - <site name>. For example, that
       # might be 'Tech - Chris Krycho' if it were for the "Tech" category on
       # my personal website.
-      taxonomies:
-        - category
-        - tag
-
-      # TODO: Something like this---
-      custom:
-        - Art and Tech:
-            taxonomies:
-              - category: art
-              - category: tech
-        - Family Poetry:
-            taxonomies:
-              - tag: family
-              - tag: poetry
-
+      - name: Art and Tech
+        taxonomies:
+          - taxonomy: category
+            terms:
+              - art
+              - tech
+      - name: Family Poetry
+        taxonomies:
+          - taxonomy: tag
+            terms:
+              - family
+              - poetry
 
   # Define rules for other content to include or exclude.
   other_content:


### PR DESCRIPTION
Note: this does not yet implement syntax highlighting support; that'll come in a follow-on set of PRs. One will just do a basic highlight pass using Syntect's support for doing full highlighting; the other will support generating the appropriate spans *only* so that people can get the benefits of the analysis server-side, while supplying CSS to actually render it in the browser.

Part 1 of #38.